### PR TITLE
Add a stack yaml and missing substituteTimeSpecifier

### DIFF
--- a/src/Data/Time/LocalTime/Short.hs
+++ b/src/Data/Time/LocalTime/Short.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP, DerivingStrategies, DeriveAnyClass #-}
 module Data.Time.LocalTime.Short
   ( ShortZonedTime
   , shortZonedTime
@@ -43,7 +43,8 @@ import           Data.Time.Format.Internal
 newtype ShortZonedTime
   = ShortZonedTime
   { unShortZonedTime :: T.ZonedTime
-  } deriving (FormatTime, NFData, Generic, FromJSON, ToJSON)
+  } deriving stock (Generic)
+  deriving newtype (FormatTime, NFData, FromJSON, ToJSON)
 
 shortZonedLocalDay :: ShortZonedTime -> T.Day
 shortZonedLocalDay = T.localDay . T.zonedTimeToLocalTime . unShortZonedTime
@@ -69,6 +70,7 @@ shortZonedTime = coerce . clipZonedTime
 instance ParseTime ShortZonedTime where
   buildTime tl ps = shortZonedTime <$> buildTime tl ps
 #if MIN_VERSION_time(1,9,0)
+  substituteTimeSpecifier _ = substituteTimeSpecifier (Proxy @T.ZonedTime)
   parseTimeSpecifier _ = parseTimeSpecifier (Proxy @T.ZonedTime)
 #endif
 
@@ -94,7 +96,9 @@ instance Ord ShortZonedTime where
 newtype ShortLocalTime
   = ShortLocalTime
   { unShortLocalTime :: T.LocalTime
-  } deriving (Eq, Ord, FormatTime, NFData, Generic)
+  } deriving stock (Eq, Ord, Generic)
+  deriving newtype (FormatTime)
+  deriving newtype (NFData)
 
 instance Binary ShortLocalTime
 
@@ -109,6 +113,7 @@ shortLocalTime = coerce . clipLocalTime
 instance ParseTime ShortLocalTime where
   buildTime tl ps = shortLocalTime <$> buildTime tl ps
 #if MIN_VERSION_time(1,9,0)
+  substituteTimeSpecifier _ = substituteTimeSpecifier (Proxy @T.ZonedTime)
   parseTimeSpecifier _ = parseTimeSpecifier (Proxy @T.LocalTime)
 #endif
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,9 @@
+resolver: lts-19.28
+nix:
+  packages: [openssl, postgresql_14, pcre, rdkafka, lzma, zlib]
+packages:
+- .
+extra-deps:
+  - xml-lens-0.3.1@sha256:8ed0cea5a2c33d665f8e3d7116c91edc466e6954a287d90d496e70550a04493d,1115
+  - git: https://github.com/typeable/dom-parser.git
+    commit: 7d556ba528bfa216e99714f8a0d4d00f452803a9


### PR DESCRIPTION
Turns out we need substituteTimeSpecifier to be implemented. Otherwise compound formatting characters, like `%F` will not work.

This is actually a way sneaky problem, so I'd suggest checking all `ParseTime` instances everywhere now.